### PR TITLE
Add ability to set the "background" option when creating an index

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ The created indexes support the following properties
 - TTL Indexes
 - Unique
 - Collations
+- Background
 
 You can find examples [here](examples/index/main.tf)
 

--- a/docs/resources/index.md
+++ b/docs/resources/index.md
@@ -43,6 +43,7 @@ resource "mongodb_index" "example" {
 - `sparse` (Boolean) Is it a sparse index.
 - `unique` (Boolean) Is it a unique index.
 - `wildcard_projection` (Map of Number) Projection for wirldcard indexes.
+- `background` (Boolean) Create the index in the background. 
 
 ### Read-Only
 

--- a/examples/index/main.tf
+++ b/examples/index/main.tf
@@ -144,3 +144,16 @@ resource "mongodb_index" "test_collation" {
     strength = 2,
   }
 }
+
+resource "mongodb_index" "test_background" {
+  database   = "test"
+  collection = "test"
+  name       = "background"
+  keys = [
+    {
+      "field" : "f1",
+      "type" : "asc"
+    }
+  ]
+  background = true
+}

--- a/internal/provider/index_resource.go
+++ b/internal/provider/index_resource.go
@@ -48,6 +48,7 @@ type indexResourceModel struct {
 	Unique             *bool             `tfsdk:"unique"`
 	WildcardProjection *map[string]int32 `tfsdk:"wildcard_projection"`
 	Collation          *collation        `tfsdk:"collation"`
+	background		   *bool             `tfsdk:"background"`
 
 	// see https://developer.hashicorp.com/terraform/plugin/framework/acctests#implement-id-attribute
 	Id types.String `tfsdk:"id"`
@@ -181,6 +182,12 @@ func (r *indexResource) Schema(_ context.Context, _ resource.SchemaRequest, resp
 					mapplanmodifier.RequiresReplace(),
 				},
 			},
+			"background": schema.BoolAttribute{
+				Description: "Create the index in the background.",
+				Optional:    true,
+				PlanModifiers: []planmodifier.Bool{
+					boolplanmodifier.RequiresReplace(),
+				},
 			"collation": schema.SingleNestedAttribute{
 				Description: "Index collation.",
 				Optional:    true,
@@ -292,6 +299,7 @@ func (r *indexResource) Create(ctx context.Context, req resource.CreateRequest, 
 		ExpireAfterSeconds: plan.ExpireAfterSeconds,
 		Unique:             plan.Unique,
 		Collation:          plan.Collation.toMongoCollation(),
+		Background: 	    plan.background,
 	}
 	if plan.WildcardProjection != nil {
 		options.WildcardProjection = plan.WildcardProjection

--- a/internal/provider/index_resource.go
+++ b/internal/provider/index_resource.go
@@ -48,7 +48,7 @@ type indexResourceModel struct {
 	Unique             *bool             `tfsdk:"unique"`
 	WildcardProjection *map[string]int32 `tfsdk:"wildcard_projection"`
 	Collation          *collation        `tfsdk:"collation"`
-	background		   *bool             `tfsdk:"background"`
+	Background		   *bool             `tfsdk:"background"`
 
 	// see https://developer.hashicorp.com/terraform/plugin/framework/acctests#implement-id-attribute
 	Id types.String `tfsdk:"id"`

--- a/internal/provider/index_resource.go
+++ b/internal/provider/index_resource.go
@@ -48,7 +48,7 @@ type indexResourceModel struct {
 	Unique             *bool             `tfsdk:"unique"`
 	WildcardProjection *map[string]int32 `tfsdk:"wildcard_projection"`
 	Collation          *collation        `tfsdk:"collation"`
-	Background		   *bool             `tfsdk:"background"`
+	Background         *bool             `tfsdk:"background"`
 
 	// see https://developer.hashicorp.com/terraform/plugin/framework/acctests#implement-id-attribute
 	Id types.String `tfsdk:"id"`

--- a/internal/provider/index_resource_test.go
+++ b/internal/provider/index_resource_test.go
@@ -37,6 +37,7 @@ resource "mongodb_index" "acc_test" {
 					resource.TestCheckNoResourceAttr("mongodb_index.acc_test", "unique"),
 					resource.TestCheckNoResourceAttr("mongodb_index.acc_test", "wildcard_projection"),
 					resource.TestCheckNoResourceAttr("mongodb_index.acc_test", "collation"),
+					resource.TestCheckNoResourceAttr("mongodb_index.acc_test", "background"),
 				),
 			},
 			// ImportState testing
@@ -78,6 +79,7 @@ resource "mongodb_index" "acc_test" {
 					resource.TestCheckNoResourceAttr("mongodb_index.acc_test", "unique"),
 					resource.TestCheckNoResourceAttr("mongodb_index.acc_test", "wildcard_projection"),
 					resource.TestCheckNoResourceAttr("mongodb_index.acc_test", "collation"),
+					resource.TestCheckNoResourceAttr("mongodb_index.acc_test", "background"),
 				),
 			},
 			// Delete testing automatically occurs in TestCase


### PR DESCRIPTION
Add ability to set the "background" option when creating an index. This is pretty much required to avoid issues when deploying to Prod and not expecting any down time.

I'm no Go/Terraform expert so just let me know if there's anything extra you want me to add.