### PR TITLE
Added support for partial_filter_expression - Fixed failing tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ The provider can be used to create indexes in a collection. The supported types 
 - Geospatial Indexes
 - Hashed Indexes
 - Wildcard Indexes
+- Partial Filter Indexes
 
 The created indexes support the following properties
 
@@ -47,6 +48,7 @@ The created indexes support the following properties
 - Unique
 - Collations
 - Background
+- Partial Filter Expression
 
 You can find examples [here](examples/index/main.tf)
 

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ Index id must use the format `<database>.<collection>.<index_name>`.
 
 ## Known issues
 
-### Index import and collation/wildcard projection
+### Index import and collation/wildcard projection/partial_filter_expression
 
 Even though index collations and wildcard projections are supported when creating index
 they do NOT work with import. The `IndexSpecification` returned by the mongo driver when

--- a/examples/index/main.tf
+++ b/examples/index/main.tf
@@ -157,3 +157,18 @@ resource "mongodb_index" "test_background" {
   ]
   background = true
 }
+
+resource "mongodb_index" "test_partial_filter" {
+  database   = "test"
+  collection = "test"
+  name       = "partial_filter"
+  keys = [
+    {
+      "field" : "user_id",
+      "type" : "asc"
+    }
+  ]
+  partial_filter_expression = jsonencode({
+    "status" : "active"
+  })
+}

--- a/internal/provider/index_resource.go
+++ b/internal/provider/index_resource.go
@@ -2,6 +2,7 @@ package provider
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 
 	"github.com/hashicorp/terraform-plugin-framework-validators/listvalidator"
@@ -39,16 +40,17 @@ type indexResource struct {
 
 // indexResourceModel maps the resource schema data.
 type indexResourceModel struct {
-	Database           string            `tfsdk:"database"`
-	Collection         string            `tfsdk:"collection"`
-	Name               string            `tfsdk:"name"`
-	Keys               []indexKey        `tfsdk:"keys"`
-	Sparse             *bool             `tfsdk:"sparse"`
-	ExpireAfterSeconds *int32            `tfsdk:"expire_after_seconds"`
-	Unique             *bool             `tfsdk:"unique"`
-	WildcardProjection *map[string]int32 `tfsdk:"wildcard_projection"`
-	Collation          *collation        `tfsdk:"collation"`
-	Background         *bool             `tfsdk:"background"`
+	Database                string            `tfsdk:"database"`
+	Collection              string            `tfsdk:"collection"`
+	Name                    string            `tfsdk:"name"`
+	Keys                    []indexKey        `tfsdk:"keys"`
+	Sparse                  *bool             `tfsdk:"sparse"`
+	ExpireAfterSeconds      *int32            `tfsdk:"expire_after_seconds"`
+	Unique                  *bool             `tfsdk:"unique"`
+	WildcardProjection      *map[string]int32 `tfsdk:"wildcard_projection"`
+	PartialFilterExpression *string           `tfsdk:"partial_filter_expression"`
+	Collation               *collation        `tfsdk:"collation"`
+	Background              *bool             `tfsdk:"background"`
 
 	// see https://developer.hashicorp.com/terraform/plugin/framework/acctests#implement-id-attribute
 	Id types.String `tfsdk:"id"`
@@ -182,6 +184,13 @@ func (r *indexResource) Schema(_ context.Context, _ resource.SchemaRequest, resp
 					mapplanmodifier.RequiresReplace(),
 				},
 			},
+			"partial_filter_expression": schema.StringAttribute{
+				Description: "A JSON string representing a filter expression for partial indexes.",
+				Optional:    true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
+			},
 			"background": schema.BoolAttribute{
 				Description: "Create the index in the background.",
 				Optional:    true,
@@ -305,6 +314,20 @@ func (r *indexResource) Create(ctx context.Context, req resource.CreateRequest, 
 	if plan.WildcardProjection != nil {
 		options.WildcardProjection = plan.WildcardProjection
 	}
+	if plan.PartialFilterExpression != nil {
+		var filterExpr bson.M
+		err := json.Unmarshal([]byte(*plan.PartialFilterExpression), &filterExpr)
+		if err != nil {
+			resp.Diagnostics.AddError(
+				"Unable to parse partial_filter_expression",
+				"The partial_filter_expression must be valid JSON. "+
+					"If the error is not clear, please contact the provider developers.\n\n"+
+					"Error: "+err.Error(),
+			)
+			return
+		}
+		options.PartialFilterExpression = filterExpr
+	}
 
 	name, err := collection.Indexes().CreateOne(ctx, mongo.IndexModel{Keys: keys, Options: options})
 	if err != nil {
@@ -408,6 +431,9 @@ func (r *indexResource) Read(ctx context.Context, req resource.ReadRequest, resp
 	state.ExpireAfterSeconds = foundIndex.ExpireAfterSeconds
 	state.Unique = foundIndex.Unique
 	state.Id = types.StringValue("to_be_ignored")
+
+	// Note: PartialFilterExpression is not exposed by mongo.IndexSpecification,
+	// so we cannot read it back from MongoDB. Terraform will manage this value from state.
 
 	// Set refreshed state
 	diags = resp.State.Set(ctx, &state)

--- a/internal/provider/index_resource.go
+++ b/internal/provider/index_resource.go
@@ -432,8 +432,49 @@ func (r *indexResource) Read(ctx context.Context, req resource.ReadRequest, resp
 	state.Unique = foundIndex.Unique
 	state.Id = types.StringValue("to_be_ignored")
 
-	// Note: PartialFilterExpression is not exposed by mongo.IndexSpecification,
-	// so we cannot read it back from MongoDB. Terraform will manage this value from state.
+	indexesCursor, err := collection.Indexes().List(ctx)
+	if err != nil {
+		resp.Diagnostics.AddError(
+			"Unable to list indexes",
+			"An unexpected error occurred when listing indexes. "+
+				"If the error is not clear, please contact the provider developers.\n\n"+
+				"Error: "+err.Error(),
+		)
+		return
+	}
+	defer indexesCursor.Close(ctx)
+
+	for indexesCursor.Next(ctx) {
+		rawIndex := indexesCursor.Current
+
+		nameValue := rawIndex.Lookup("name")
+		if nameValue.Type != 0 && nameValue.StringValue() == indexName {
+			partialFilterValue := rawIndex.Lookup("partialFilterExpression")
+			if partialFilterValue.Type != 0 {
+				// Normalize the JSON to avoid whitespace differences
+				var filterExpr interface{}
+				err := json.Unmarshal([]byte(partialFilterValue.String()), &filterExpr)
+				if err == nil {
+					normalizedJSON, err := json.Marshal(filterExpr)
+					if err == nil {
+						partialFilterExpression := string(normalizedJSON)
+						state.PartialFilterExpression = &partialFilterExpression
+					}
+				}
+			}
+			break
+		}
+	}
+
+	if err := indexesCursor.Err(); err != nil {
+		resp.Diagnostics.AddError(
+			"Unable to list indexes",
+			"An unexpected error occurred when listing indexes. "+
+				"If the error is not clear, please contact the provider developers.\n\n"+
+				"Error: "+err.Error(),
+		)
+		return
+	}
 
 	// Set refreshed state
 	diags = resp.State.Set(ctx, &state)

--- a/internal/provider/index_resource_test.go
+++ b/internal/provider/index_resource_test.go
@@ -106,9 +106,7 @@ resource "mongodb_index" "partial_filter_test" {
       "type" : "asc"
     }
   ]
-  partial_filter_expression = jsonencode({
-    "status" : "active"
-  })
+  partial_filter_expression = jsonencode({"status" : "active"})
 }
 `,
 				Check: resource.ComposeAggregateTestCheckFunc(

--- a/internal/provider/index_resource_test.go
+++ b/internal/provider/index_resource_test.go
@@ -36,6 +36,7 @@ resource "mongodb_index" "acc_test" {
 					resource.TestCheckNoResourceAttr("mongodb_index.acc_test", "expire_after_seconds"),
 					resource.TestCheckNoResourceAttr("mongodb_index.acc_test", "unique"),
 					resource.TestCheckNoResourceAttr("mongodb_index.acc_test", "wildcard_projection"),
+					resource.TestCheckNoResourceAttr("mongodb_index.acc_test", "partial_filter_expression"),
 					resource.TestCheckNoResourceAttr("mongodb_index.acc_test", "collation"),
 					resource.TestCheckNoResourceAttr("mongodb_index.acc_test", "background"),
 				),
@@ -78,11 +79,54 @@ resource "mongodb_index" "acc_test" {
 					resource.TestCheckNoResourceAttr("mongodb_index.acc_test", "expire_after_seconds"),
 					resource.TestCheckNoResourceAttr("mongodb_index.acc_test", "unique"),
 					resource.TestCheckNoResourceAttr("mongodb_index.acc_test", "wildcard_projection"),
+					resource.TestCheckNoResourceAttr("mongodb_index.acc_test", "partial_filter_expression"),
 					resource.TestCheckNoResourceAttr("mongodb_index.acc_test", "collation"),
 					resource.TestCheckNoResourceAttr("mongodb_index.acc_test", "background"),
 				),
 			},
 			// Delete testing automatically occurs in TestCase
+		},
+	})
+}
+
+func TestAccIndexResourceWithPartialFilterExpression(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			// Create and Read testing with partial filter expression
+			{
+				Config: providerConfig + `
+resource "mongodb_index" "partial_filter_test" {
+  database   = "test"
+  collection = "test"
+  name       = "partial_filter_idx"
+  keys = [
+    {
+      "field" : "status"
+      "type" : "asc"
+    }
+  ]
+  partial_filter_expression = jsonencode({
+    "status" : "active"
+  })
+}
+`,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("mongodb_index.partial_filter_test", "database", "test"),
+					resource.TestCheckResourceAttr("mongodb_index.partial_filter_test", "collection", "test"),
+					resource.TestCheckResourceAttr("mongodb_index.partial_filter_test", "name", "partial_filter_idx"),
+					resource.TestCheckResourceAttr("mongodb_index.partial_filter_test", "keys.0.field", "status"),
+					resource.TestCheckResourceAttr("mongodb_index.partial_filter_test", "keys.0.type", "asc"),
+					resource.TestCheckResourceAttrSet("mongodb_index.partial_filter_test", "partial_filter_expression"),
+				),
+			},
+			// ImportState testing
+			{
+				ResourceName:      "mongodb_index.partial_filter_test",
+				ImportStateId:     "test.test.partial_filter_idx",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
 		},
 	})
 }


### PR DESCRIPTION
Added support for partial_filter_expression.

Locally the tests are now working:

TF_ACC=1 MONGODB_URL=mongodb://localhost:27017 go test ./... -v
?       terraform-provider-mongodb      [no test files]
=== RUN   TestAccIndexResource
--- PASS: TestAccIndexResource (1.34s)
=== RUN   TestAccIndexResourceWithPartialFilterExpression
--- PASS: TestAccIndexResourceWithPartialFilterExpression (0.91s)
=== RUN   TestConvertToMongoIndexTypeAsc
--- PASS: TestConvertToMongoIndexTypeAsc (0.00s)
=== RUN   TestConvertToMongoIndexTypeDesc
--- PASS: TestConvertToMongoIndexTypeDesc (0.00s)
=== RUN   TestConvertToMongoIndexTypeStr
--- PASS: TestConvertToMongoIndexTypeStr (0.00s)
=== RUN   TestConvertToTfIndexTypeAsc
--- PASS: TestConvertToTfIndexTypeAsc (0.00s)
=== RUN   TestConvertToTfIndexTypeDesc
--- PASS: TestConvertToTfIndexTypeDesc (0.00s)
=== RUN   TestConvertToTfIndexTypeStr
--- PASS: TestConvertToTfIndexTypeStr (0.00s)
=== RUN   TestConvertToTfIndexTypeTypeError
--- PASS: TestConvertToTfIndexTypeTypeError (0.00s)
=== RUN   TestParseValidIndexId
--- PASS: TestParseValidIndexId (0.00s)
=== RUN   TestParseInvalidIndex
--- PASS: TestParseInvalidIndex (0.00s)
PASS
ok      terraform-provider-mongodb/internal/provider